### PR TITLE
<Refact> : Fetch 기반 코드를 Axios 기반 코드로 통신 코드 전환

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.3.6",
         "browser-image-compression": "^2.0.2",
         "install": "^0.13.0",
         "react": "^18.2.0",
@@ -5021,6 +5022,29 @@
       "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.6.tgz",
+      "integrity": "sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14110,6 +14134,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -20826,6 +20855,28 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
       "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA=="
     },
+    "axios": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.6.tgz",
+      "integrity": "sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -27234,6 +27285,11 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.3.6",
     "browser-image-compression": "^2.0.2",
     "install": "^0.13.0",
     "react": "^18.2.0",

--- a/src/api/axios_profileAPI.js
+++ b/src/api/axios_profileAPI.js
@@ -1,0 +1,7 @@
+import { instance } from '../axios/axios';
+
+const getUserInfo2 = async (accountname) => {
+  const response = await instance.get(`/profile/${accountname}`);
+  return response.data;
+};
+export default getUserInfo2;

--- a/src/api/axios_profileAPI.js
+++ b/src/api/axios_profileAPI.js
@@ -1,7 +1,0 @@
-import { instance } from '../axios/axios';
-
-const getUserInfo2 = async (accountname) => {
-  const response = await instance.get(`/profile/${accountname}`);
-  return response.data;
-};
-export default getUserInfo2;

--- a/src/api/commentAPI.js
+++ b/src/api/commentAPI.js
@@ -1,51 +1,25 @@
-import BASE_URL from '../utils/baseUrl';
+import { instance } from '../axios/axios';
 
 const commentAPI = {
-  async uploadComment(token, postId, text) {
-    const response = await fetch(`${BASE_URL}/post/${postId}/comments`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        comment: {
-          content: `${text}`,
-        },
-      }),
+  async uploadComment(postId, text) {
+    const response = await instance.post(`/post/${postId}/comments`, {
+      comment: { content: `${text}` },
     });
-    const data = await response.json();
-    return data;
+    return response.data;
   },
 
-  async deleteComment(token, postId, commentid) {
-    const response = await fetch(
-      `${BASE_URL}/post/${postId}/comments/${commentid}`,
-      {
-        method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      },
+  async deleteComment(postId, commentid) {
+    const response = await instance.delete(
+      `/post/${postId}/comments/${commentid}`,
     );
-    const data = await response.json();
-    return data;
+    return response.data;
   },
 
-  async reportComment(token, postId, commentid) {
-    const response = await fetch(
-      `${BASE_URL}/post/${postId}/comments/${commentid}/report`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      },
+  async reportComment(postId, commentid) {
+    const response = await instance.post(
+      `/post/${postId}/comments/${commentid}/report`,
     );
-    const data = await response.json();
-    return data;
+    return response.data;
   },
 };
 

--- a/src/api/followAPI.js
+++ b/src/api/followAPI.js
@@ -1,31 +1,14 @@
-import BASE_URL from '../utils/baseUrl';
+import { instance } from '../axios/axios';
 
 const followAPI = {
-  async followingPost(token, pageAccount) {
-    const response = await fetch(`${BASE_URL}/profile/${pageAccount}/follow`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
+  async followingPost(pageAccount) {
+    const response = await instance.post(`/profile/${pageAccount}/follow`);
+    return response.data;
   },
 
-  async unfollowingPost(token, pageAccount) {
-    const response = await fetch(
-      `${BASE_URL}/profile/${pageAccount}/unfollow`,
-      {
-        method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      },
-    );
-    const data = await response.json();
-    return data;
+  async unfollowingPost(pageAccount) {
+    const response = await instance.delete(`/profile/${pageAccount}/unfollow`);
+    return response.data;
   },
 };
 

--- a/src/api/imageAPI.js
+++ b/src/api/imageAPI.js
@@ -1,18 +1,15 @@
 import BASE_URL from '../utils/baseUrl';
+import { imgInstance } from '../axios/axios';
 
 const imageAPI = {
   async uploadImg(e) {
     const imageFile = e.target.files[0];
     const formData = new FormData();
+    console.log(formData);
     formData.append('image', imageFile);
 
-    const response = await fetch(`${BASE_URL}/image/uploadfile`, {
-      method: 'POST',
-      body: formData,
-    });
-
-    const data = await response.json();
-    const imageSrc = `${BASE_URL}/${data.filename}`;
+    const response = await imgInstance.post(`/image/uploadfile`, formData);
+    const imageSrc = `${BASE_URL}/${response.data.filename}`;
     return imageSrc;
   },
 };

--- a/src/api/imageAPI.js
+++ b/src/api/imageAPI.js
@@ -5,7 +5,6 @@ const imageAPI = {
   async uploadImg(e) {
     const imageFile = e.target.files[0];
     const formData = new FormData();
-    console.log(formData);
     formData.append('image', imageFile);
 
     const response = await imgInstance.post(`/image/uploadfile`, formData);

--- a/src/api/likeAPI.js
+++ b/src/api/likeAPI.js
@@ -1,28 +1,14 @@
-import BASE_URL from '../utils/baseUrl';
+import { instance } from '../axios/axios';
 
 const likeAPI = {
-  async getHeart(token, postId) {
-    const response = await fetch(`${BASE_URL}/post/${postId}/heart`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
+  async getHeart(postId) {
+    const response = await instance.post(`/post/${postId}/heart`);
+    return response.data;
   },
 
-  async cancelHeart(token, postId) {
-    const response = await fetch(`${BASE_URL}/post/${postId}/unheart`, {
-      method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
+  async cancelHeart(postId) {
+    const response = await instance.delete(`/post/${postId}/unheart`);
+    return response.data;
   },
 };
 

--- a/src/api/postAPI.js
+++ b/src/api/postAPI.js
@@ -1,65 +1,25 @@
 import imageCompression from 'browser-image-compression';
-import BASE_URL from '../utils/baseUrl';
+import { instance } from '../axios/axios';
 
 const postAPI = {
-  async loadFeed(token) {
-    const response = await fetch(`${BASE_URL}/post/feed`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
+  async loadFeed() {
+    const response = await instance.get(`/post/feed`);
+    return response.data;
   },
 
-  async getMyPost(token, pageAccount) {
-    const response = await fetch(`${BASE_URL}/post/${pageAccount}/userpost`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
+  async getMyPost(pageAccount) {
+    const response = await instance.get(`/post/${pageAccount}/userpost`);
+    return response.data;
   },
 
-  async deletePost(token, postId) {
-    const response = await fetch(`${BASE_URL}/post/${postId}`, {
-      method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
+  async deletePost(postId) {
+    const response = await instance.delete(`/post/${postId}`);
+    return response.data;
   },
 
-  async reportPost(token, postId) {
-    const response = await fetch(`${BASE_URL}/post/${postId}/report`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
-  },
-
-  async getUserProfile(token, accountname) {
-    const response = await fetch(`${BASE_URL}/profile/${accountname}`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
+  async reportPost(postId) {
+    const response = await instance.post(`/post/${postId}/report`);
+    return response.data;
   },
 
   async postUploadImgs(file) {
@@ -76,85 +36,44 @@ const postAPI = {
     const formData = new FormData();
     formData.append('image', newFile);
 
-    const response = await fetch(`${BASE_URL}/image/uploadfiles`, {
-      method: 'POST',
-      body: formData,
-    });
-
-    const data = await response.json();
-    return data;
+    const response = await instance.post(`/image/uploadfiles`, formData);
+    return response.data;
   },
 
-  async createPost(token, contentText, img) {
-    const response = await fetch(`${BASE_URL}/post`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
+  async createPost(contentText, img) {
+    const response = await instance.post(`/post`, {
+      post: {
+        content: contentText,
+        image: img.join(', '),
       },
-      body: JSON.stringify({
-        post: {
-          content: contentText,
-          image: img.join(', '),
-        },
-      }),
     });
-    const data = await response.json();
-    return data;
+    return response.data;
   },
 
-  async editPost(token, postid, contentText, img) {
-    const response = await fetch(`${BASE_URL}/post/${postid}`, {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
+  async editPost(postid, contentText, img) {
+    const response = await instance.put(`/post/${postid}`, {
+      post: {
+        content: `${contentText}`,
+        image: img.join(','),
       },
-      body: JSON.stringify({
-        post: {
-          content: `${contentText}`,
-          image: img.join(','),
-        },
-      }),
     });
-    const data = await response.json();
-    return data;
+    return response.data;
   },
 
-  async getPost(token, postid) {
-    const response = await fetch(`${BASE_URL}/post/${postid}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    const postContent = data.post;
+  async getPost(postid) {
+    const response = await instance.get(`/post/${postid}`);
+    const postContent = response.data.post;
     return postContent;
   },
 
-  async getComment(token, postid) {
-    const response = await fetch(`${BASE_URL}/post/${postid}/comments`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
+  async getComment(postid) {
+    const response = await instance.get(`/post/${postid}/comments`);
+    return response.data;
   },
 
-  async getUserPost(token, postid) {
-    const response = await fetch(`${BASE_URL}/post/${postid}`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
+  async getUserPost(postid) {
+    const response = await instance.get(`/post/${postid}`);
+    return response.data;
   },
 };
 

--- a/src/api/productAPI.js
+++ b/src/api/productAPI.js
@@ -1,72 +1,25 @@
-import BASE_URL from '../utils/baseUrl';
+import { instance } from '../axios/axios';
 
 const productAPI = {
-  async registerProduct(reqData, token) {
-    const response = await fetch(`${BASE_URL}/product`, {
-      method: 'POST',
-
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-      body: JSON.stringify(reqData),
-    });
-    const data = await response.json();
-    return data;
+  async registerProduct(reqData) {
+    const response = await instance.post(`/product`, reqData);
+    return response.data;
   },
-  async loadProductFeed(token, pageAccount) {
-    const response = await fetch(`${BASE_URL}/product/${pageAccount}`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
+  async loadProductFeed(pageAccount) {
+    const response = await instance.get(`/product/${pageAccount}`);
+    return response.data;
   },
-  async getOriginalProductInfo(token, productid) {
-    const response = await fetch(
-      `https://mandarin.api.weniv.co.kr/product/detail/${productid}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      },
-    );
-    const data = await response.json();
-    return data;
+  async getOriginalProductInfo(productid) {
+    const response = await instance.get(`/product/detail/${productid}`);
+    return response.data;
   },
-  async reviseProductInfo(token, productid, updateData) {
-    const response = await fetch(
-      `https://mandarin.api.weniv.co.kr/product/${productid}`,
-      {
-        method: 'PUT',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-        body: JSON.stringify(updateData),
-      },
-    );
-    const data = await response.json();
-    return data;
+  async reviseProductInfo(productid, updateData) {
+    const response = await instance.put(`/product/${productid}`, updateData);
+    return response.data;
   },
-  async deleteProduct(token, productId) {
-    const response = await fetch(
-      `https://mandarin.api.weniv.co.kr/product/${productId}`,
-      {
-        method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      },
-    );
-    const data = await response.json();
-    return data;
+  async deleteProduct(productId) {
+    const response = await instance.delete(`/product/${productId}`);
+    return response.data;
   },
 };
 

--- a/src/api/profileAPI.js
+++ b/src/api/profileAPI.js
@@ -1,49 +1,24 @@
+// import axios from 'axios';
+import { instance } from '../axios/axios';
 import BASE_URL from '../utils/baseUrl';
 
 const profileAPI = {
   // UserProfile 데이터
-  async getUserInfo(token, accountname) {
-    const response = await fetch(`${BASE_URL}/profile/${accountname}`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
+  async getUserInfo(accountname) {
+    const response = await instance.get(`/profile/${accountname}`);
+    return response.data;
   },
 
   // FollweList 데이터
-  async getFollowerList(token, accountName) {
-    const response = await fetch(
-      `${BASE_URL}/profile/${accountName}/follower`,
-      {
-        method: `GET`,
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      },
-    );
-    const data = await response.json();
-    return data;
+  async getFollowerList(accountName) {
+    const response = await instance.get(`/profile/${accountName}/follower`);
+    return response.data;
   },
 
   // FollowingList 데이터
   async getFollowingdata(token, accountName) {
-    const response = await fetch(
-      `${BASE_URL}/profile/${accountName}/following`,
-      {
-        method: `GET`,
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      },
-    );
-    const data = await response.json();
-    return data;
+    const response = await instance(`/profile/${accountName}/following`);
+    return response.data;
   },
 
   async putModifyData(username, accountname, intro, image, Token) {

--- a/src/api/profileAPI.js
+++ b/src/api/profileAPI.js
@@ -1,27 +1,26 @@
-// import axios from 'axios';
 import { instance } from '../axios/axios';
-import BASE_URL from '../utils/baseUrl';
 
 const profileAPI = {
-  // UserProfile 데이터
+  // UserProfile 데이터 서버통신 함수
   async getUserInfo(accountname) {
     const response = await instance.get(`/profile/${accountname}`);
     return response.data;
   },
 
-  // FollweList 데이터
+  // FollweList 데이터 서버통신 함수
   async getFollowerList(accountName) {
     const response = await instance.get(`/profile/${accountName}/follower`);
     return response.data;
   },
 
-  // FollowingList 데이터
-  async getFollowingdata(token, accountName) {
+  // FollowingList 데이터 서버통신 함수
+  async getFollowingdata(accountName) {
     const response = await instance(`/profile/${accountName}/following`);
     return response.data;
   },
 
-  async putModifyData(username, accountname, intro, image, Token) {
+  // ModifyPrifle 데이터 서버통신 함수
+  async putModifyData(username, accountname, intro, image) {
     const userData = {
       user: {
         username,
@@ -30,16 +29,9 @@ const profileAPI = {
         image,
       },
     };
-    const response = await fetch(`${BASE_URL}/user`, {
-      method: 'PUT',
-      body: JSON.stringify(userData),
-      headers: {
-        Authorization: `Bearer ${Token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
+    const response = await instance.put(`/user`, userData);
+    console.log(response);
+    return response.data;
   },
 };
 export default profileAPI;

--- a/src/api/profileAPI.js
+++ b/src/api/profileAPI.js
@@ -30,7 +30,6 @@ const profileAPI = {
       },
     };
     const response = await instance.put(`/user`, userData);
-    console.log(response);
     return response.data;
   },
 };

--- a/src/api/searchAPI.js
+++ b/src/api/searchAPI.js
@@ -1,19 +1,9 @@
-import BASE_URL from '../utils/baseUrl';
+import { instance } from '../axios/axios';
 
 const searchAPI = {
-  async searchUser(keyword, token) {
-    const response = await fetch(
-      `${BASE_URL}/user/searchuser/?keyword=${keyword}`,
-      {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      },
-    );
-    const data = await response.json();
-    return data;
+  async searchUser(keyword) {
+    const response = await instance.get(`/user/searchuser/?keyword=${keyword}`);
+    return response.data;
   },
 };
 

--- a/src/api/userAPI.js
+++ b/src/api/userAPI.js
@@ -1,4 +1,4 @@
-import BASE_URL from '../utils/baseUrl';
+import { instance } from '../axios/axios';
 
 const userAPI = {
   async getSignUp(username, email, password, accountname, intro, image) {
@@ -12,77 +12,41 @@ const userAPI = {
         image,
       },
     };
-
-    const response = await fetch(`${BASE_URL}/user`, {
-      method: 'POST',
-      headers: {
-        'Content-type': 'application/json',
-      },
-      body: JSON.stringify(userData),
-    });
-
-    const data = await response.json();
-    return data;
+    const response = await instance.post(`/user`, userData);
+    return response.data;
   },
 
   async getLogin(email, password) {
-    const response = await fetch(`${BASE_URL}/user/login`, {
-      method: 'POST',
-      headers: {
-        'Content-type': 'application/json',
+    const response = await instance.post(`/user/login`, {
+      user: {
+        email,
+        password,
       },
-      body: JSON.stringify({
-        user: {
-          email,
-          password,
-        },
-      }),
     });
-    const data = await response.json();
-    return data;
+    return response.data;
   },
 
   async checkEmailValid(email) {
-    const response = await fetch(`${BASE_URL}/user/emailvalid`, {
-      method: 'POST',
-      headers: {
-        'Content-type': 'application/json',
+    const response = await instance.post(`/user/emailvalid`, {
+      user: {
+        email,
       },
-      body: JSON.stringify({
-        user: {
-          email,
-        },
-      }),
     });
-    const data = await response.json();
-    return data;
+    return response.data;
   },
 
   async checkAccountValid(accountname) {
-    const response = await fetch(`${BASE_URL}/user/accountnamevalid`, {
-      method: 'POST',
-      headers: {
-        'Content-type': 'application/json',
+    const response = await instance.post(`/user/accountnamevalid`, {
+      user: {
+        accountname,
       },
-      body: JSON.stringify({
-        user: {
-          accountname,
-        },
-      }),
     });
-    const data = await response.json();
-    return data;
+    return response.data;
   },
 
-  async getMyinfo(token) {
-    const response = await fetch(`${BASE_URL}/user/myinfo`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    const data = await response.json();
-    return data;
+  async getMyinfo() {
+    const response = await instance.get(`/user/myinfo`);
+    return response.data;
   },
 };
 

--- a/src/axios/axios.js
+++ b/src/axios/axios.js
@@ -6,6 +6,11 @@ export const instance = axios.create({
   headers: { 'Context-type': 'application/json' },
 });
 
+export const imgInstance = axios.create({
+  baseURL: BASE_URL,
+  headers: { 'Context-type': 'multipart/form-data' },
+});
+
 instance.interceptors.request.use((config) => {
   if (!config.headers.Authorization) {
     /* eslint-disable-next-line no-param-reassign */

--- a/src/axios/axios.js
+++ b/src/axios/axios.js
@@ -22,4 +22,4 @@ instance.interceptors.request.use((config) => {
   return config;
 });
 
-export default { instance };
+export default { instance, imgInstance };

--- a/src/axios/axios.js
+++ b/src/axios/axios.js
@@ -1,0 +1,20 @@
+import axios from 'axios';
+import BASE_URL from '../utils/baseUrl';
+
+export const instance = axios.create({
+  baseURL: BASE_URL,
+  headers: { 'Context-type': 'application/json' },
+});
+
+instance.interceptors.request.use((config) => {
+  if (!config.headers.Authorization) {
+    /* eslint-disable-next-line no-param-reassign */
+    config.headers = {
+      ...config.headers,
+      Authorization: `Bearer ${localStorage.getItem('token')}`,
+    };
+  }
+  return config;
+});
+
+export default { instance };

--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from 'react';
 import commentAPI from '../../api/commentAPI';
-import postAPI from '../../api/postAPI';
+// import postAPI from '../../api/postAPI';
+import profileAPI from '../../api/profileAPI';
 import { AuthContext } from '../../context/context';
 import ProfileImg from '../common/ProfileImg/ProfileImg';
 import * as S from './StyledCommentInput';
@@ -40,8 +41,8 @@ const CommentInput = ({ postid, handleGetComment, setCommentsData }) => {
   useEffect(() => {
     const getUserProfile = async () => {
       try {
-        postAPI
-          .getUserProfile(user.token, user.accountname)
+        profileAPI
+          .getUserInfo(user.accountname)
           .then((data) => setProfileImg(data.profile.image));
       } catch (error) {
         console.error(error);

--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -26,7 +26,7 @@ const CommentInput = ({ postid, handleGetComment, setCommentsData }) => {
 
     try {
       commentAPI
-        .uploadComment(user.token, postid, text)
+        .uploadComment(postid, text)
         .then((data) =>
           setCommentsData((prev) => [{ ...data.comment }, ...prev]),
         );

--- a/src/components/PostForm/PostForm.jsx
+++ b/src/components/PostForm/PostForm.jsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AuthContext } from '../../context/context';
+import profileAPI from '../../api/profileAPI';
 import postAPI from '../../api/postAPI';
 import Nav from '../Nav/Nav';
 import ProfileImg from '../common/ProfileImg/ProfileImg';
@@ -17,8 +18,8 @@ const PostForm = ({ editing }) => {
 
   useEffect(() => {
     try {
-      postAPI
-        .getUserProfile(user.token, user.accountname)
+      profileAPI
+        .getUserInfo(user.accountname)
         .then((data) => setProfileImg(data.profile.image));
     } catch (error) {
       console.log(error);
@@ -58,14 +59,14 @@ const PostForm = ({ editing }) => {
 
     if (!editing) {
       try {
-        postAPI.createPost(user.token, contentText, imgSrc);
+        postAPI.createPost(contentText, imgSrc);
         navigate(`/profile/${user.accountname}`);
       } catch (error) {
         console.log(error);
       }
     } else {
       try {
-        postAPI.editPost(user.token, postid, contentText, imgSrc);
+        postAPI.editPost(postid, contentText, imgSrc);
         navigate(`/profile/${user.accountname}`);
       } catch (error) {
         console.log(error);
@@ -80,7 +81,7 @@ const PostForm = ({ editing }) => {
   useEffect(() => {
     if (editing) {
       const setPost = async () => {
-        const data = await postAPI.getPost(user.token, postid);
+        const data = await postAPI.getPost(postid);
         setContentText(data.content);
 
         if (data.image) {

--- a/src/components/ProductForm/ProductForm.jsx
+++ b/src/components/ProductForm/ProductForm.jsx
@@ -98,10 +98,7 @@ const ProductForm = ({ editing }) => {
   useEffect(() => {
     if (editing) {
       const setProductFeed = async () => {
-        const data = await productAPI.getOriginalProductInfo(
-          user.token,
-          productid,
-        );
+        const data = await productAPI.getOriginalProductInfo(productid);
         setProductImg(data.product.itemImage);
         setProductName(data.product.itemName);
         setProductPrice(priceFormat(data.product.price));
@@ -129,16 +126,13 @@ const ProductForm = ({ editing }) => {
         itemImage: `${productImg}`,
       },
     };
+    console.log(Data);
     if (editing) {
-      const UpdatedData = await productAPI.reviseProductInfo(
-        user.token,
-        productid,
-        Data,
-      );
+      const UpdatedData = await productAPI.reviseProductInfo(productid, Data);
       navigate(`/profile/${user.accountname}`);
       return UpdatedData;
     } else {
-      const originalData = await productAPI.registerProduct(Data, user.token);
+      const originalData = await productAPI.registerProduct(Data);
       navigate(`/profile/${user.accountname}`);
       return originalData;
     }

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -7,8 +7,8 @@ import MyProfileBtnWrap from './MyProfileBtnWrapp';
 
 const ProfileInfo = ({ authAccountName }) => {
   const location = useLocation();
-  const { profile } = useContext(ProfileDataContext);
   const pageAccount = location.pathname.split('/')[2];
+  const { profile } = useContext(ProfileDataContext);
 
   return (
     <S.Container>

--- a/src/components/common/Button/FollowButton.jsx
+++ b/src/components/common/Button/FollowButton.jsx
@@ -1,6 +1,5 @@
 import { useLocation } from 'react-router-dom';
 import { useState, useContext, useEffect } from 'react';
-import { AuthContext } from '../../../context/context';
 import { ProfileDataContext } from '../../../context/ProfileInfoContext';
 import Button from './Button';
 import followAPI from '../../../api/followAPI';
@@ -8,7 +7,6 @@ import followAPI from '../../../api/followAPI';
 const FollowButton = () => {
   const location = useLocation();
   const pageAccount = location.pathname.split('/')[2];
-  const { user } = useContext(AuthContext);
   const { profile, dispatch } = useContext(ProfileDataContext);
   const [isFollow, setIsFollow] = useState(profile.isfollow);
 
@@ -18,7 +16,7 @@ const FollowButton = () => {
 
   const handelIsFollow = async () => {
     if (isFollow === false) {
-      const data = await followAPI.followingPost(user.token, pageAccount);
+      const data = await followAPI.followingPost(pageAccount);
       setIsFollow(data.profile.isfollow);
       const FollowData = { ...data.profile };
       dispatch({
@@ -26,7 +24,7 @@ const FollowButton = () => {
         payload: FollowData.followerCount,
       });
     } else if (isFollow === true) {
-      const data = await followAPI.unfollowingPost(user.token, pageAccount);
+      const data = await followAPI.unfollowingPost(pageAccount);
       const FollowData = { ...data.profile };
       setIsFollow(data.profile.isfollow);
       dispatch({

--- a/src/components/common/Button/LikeButton.jsx
+++ b/src/components/common/Button/LikeButton.jsx
@@ -1,5 +1,4 @@
-import { useState, useContext } from 'react';
-import { AuthContext } from '../../../context/context';
+import { useState } from 'react';
 import likeAPI from '../../../api/likeAPI';
 import HeartOff from '../../../assets/images/icon-heart.svg';
 import HeartOn from '../../../assets/images/heart.svg';
@@ -7,19 +6,18 @@ import HeartOn from '../../../assets/images/heart.svg';
 const LikeButton = ({ heartCount, hearted, postId }) => {
   const [isLike, setIsLike] = useState(hearted);
   const [likeCount, setLikeCount] = useState(heartCount);
-  const { user } = useContext(AuthContext);
 
   const handleLikeChange = () => {
     if (isLike === false) {
       const getHeart = async () => {
-        const data = await likeAPI.getHeart(user.token, postId);
+        const data = await likeAPI.getHeart(postId);
         setIsLike(data.post.hearted);
         setLikeCount(data.post.heartCount);
       };
       getHeart();
     } else if (isLike === true) {
       const cancelHeart = async () => {
-        const data = await likeAPI.cancelHeart(user.token, postId);
+        const data = await likeAPI.cancelHeart(postId);
         setIsLike(data.post.hearted);
         setLikeCount(data.post.heartCount);
       };

--- a/src/components/common/Modals/InnerModal.jsx
+++ b/src/components/common/Modals/InnerModal.jsx
@@ -27,7 +27,7 @@ const InnerModal = ({ name, CloseInnerModal, postId, productId, comment }) => {
       window.location = '/';
     } else if (name === '게시글삭제') {
       const deletePost = async () => {
-        const data = await postAPI.deletePost(user.token, postId);
+        const data = await postAPI.deletePost(postId);
         if (data.status === '200') {
           CloseInnerModal();
           window.location.reload();
@@ -38,7 +38,7 @@ const InnerModal = ({ name, CloseInnerModal, postId, productId, comment }) => {
       deletePost();
     } else if (name === '게시글신고') {
       const reportPost = async () => {
-        const data = await postAPI.reportPost(user.token, postId);
+        const data = await postAPI.reportPost(postId);
         if (data.report) {
           // eslint-disable-next-line no-alert
           alert('신고되었습니다.');

--- a/src/components/common/Modals/InnerModal.jsx
+++ b/src/components/common/Modals/InnerModal.jsx
@@ -77,7 +77,7 @@ const InnerModal = ({ name, CloseInnerModal, postId, productId, comment }) => {
       reportComment();
     } else if (name === '상품삭제') {
       const handleDeleteProduct = async () => {
-        const data = await productAPI.deleteProduct(user.token, productId);
+        const data = await productAPI.deleteProduct(productId);
         if (parseInt(data.status, 10) === 200) {
           CloseInnerModal();
           window.location.reload();

--- a/src/components/common/Modals/InnerModal.jsx
+++ b/src/components/common/Modals/InnerModal.jsx
@@ -50,11 +50,7 @@ const InnerModal = ({ name, CloseInnerModal, postId, productId, comment }) => {
       reportPost();
     } else if (name === '댓글삭제') {
       const deleteComment = async () => {
-        const data = await commentAPI.deleteComment(
-          user.token,
-          postId,
-          comment.id,
-        );
+        const data = await commentAPI.deleteComment(postId, comment.id);
         if (data.status === '200') {
           CloseInnerModal();
           window.location.reload();

--- a/src/components/common/Product/ProductWrapp.jsx
+++ b/src/components/common/Product/ProductWrapp.jsx
@@ -1,19 +1,18 @@
-import { useContext, useEffect, useState } from 'react';
-import { AuthContext } from '../../../context/context';
+import { useEffect, useState } from 'react';
 import productAPI from '../../../api/productAPI';
 import ProductSection from './StyledProductWrapp';
 import Product from './Product';
 
 const ProductWrapp = ({ pageAccount }) => {
   const [productList, setProductList] = useState([]);
-  const { user } = useContext(AuthContext);
 
   // 판매중인 상품페이지에 상품 불러오기
   // PageAccount가 변경될 때 렌더링될 수 있도록 서버통신
   useEffect(() => {
     const setProductFeed = async () => {
-      const data = await productAPI.loadProductFeed(user.token, pageAccount);
+      const data = await productAPI.loadProductFeed(pageAccount);
       setProductList(data.product);
+      console.log(data);
     };
     setProductFeed();
   }, [pageAccount]);

--- a/src/pages/HomeFeed/HomeFeed.jsx
+++ b/src/pages/HomeFeed/HomeFeed.jsx
@@ -1,6 +1,5 @@
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AuthContext } from '../../context/context';
 import Loading from '../../components/Loading/Loading';
 import Button from '../../components/common/Button/Button';
 import PostCard from '../../components/common/PostCard/PostCard';
@@ -13,12 +12,11 @@ import * as S from './StyledHomeFeed';
 const HomeFeed = () => {
   const [feed, setFeed] = useState([]);
   const [isloading, setIsLoading] = useState(true);
-  const { user } = useContext(AuthContext);
   const navigate = useNavigate();
 
   useEffect(() => {
     const setHomeFeed = async () => {
-      const data = await postAPI.loadFeed(user.token);
+      const data = await postAPI.loadFeed();
       setFeed(data.posts);
       setIsLoading(false);
     };

--- a/src/pages/ModifyProfile/ModifyProfile.jsx
+++ b/src/pages/ModifyProfile/ModifyProfile.jsx
@@ -92,7 +92,6 @@ const ModifyProfile = () => {
       img,
       Token,
     );
-    console.log(ModifyData);
     const changeAccount = {
       token: Token,
       accountname: ModifyData.user.accountname,

--- a/src/pages/PostDetail/PostDetail.jsx
+++ b/src/pages/PostDetail/PostDetail.jsx
@@ -1,22 +1,20 @@
-import { useContext, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import postAPI from '../../api/postAPI';
 import Comment from '../../components/Comment/Comment';
 import CommentInput from '../../components/CommentInput/CommentInput';
 import PostCard from '../../components/common/PostCard/PostCard';
 import Nav from '../../components/Nav/Nav';
-import { AuthContext } from '../../context/context';
 import * as S from './StyledPostDetail';
 
 const PostDetail = () => {
-  const { user } = useContext(AuthContext);
   const { postid } = useParams();
   const [postData, setPostData] = useState();
   const [commentsData, setCommentsData] = useState([]);
 
   const handleGetComment = async () => {
     try {
-      const data = await postAPI.getComment(user.token, postid);
+      const data = await postAPI.getComment(postid);
       setCommentsData(data.comments);
     } catch (error) {
       console.log(error);
@@ -26,7 +24,7 @@ const PostDetail = () => {
   useEffect(() => {
     const getPostCard = async () => {
       try {
-        const data = await postAPI.getUserPost(user.token, postid);
+        const data = await postAPI.getUserPost(postid);
         setPostData(data.post);
       } catch (error) {
         console.log(error);

--- a/src/pages/Profile/UserProfile/UserProfile.jsx
+++ b/src/pages/Profile/UserProfile/UserProfile.jsx
@@ -30,11 +30,11 @@ const UserProfile = () => {
   const pageAccount = location.pathname.split('/')[2];
 
   const getUserProfileInfo = async () => {
-    const data = await profileAPI.getUserInfo(user.token, pageAccount);
+    // const data = await profileAPI.getUserInfo(user.token, pageAccount);
+    const data = await profileAPI.getUserInfo(pageAccount);
     setUserProfile(data.profile);
     const ProfileData = { ...data.profile };
     dispatch({ type: 'USERINFO_DATA', payload: ProfileData });
-    console.log(1);
   };
 
   const getMyPost = async () => {
@@ -42,7 +42,6 @@ const UserProfile = () => {
     setUserPostArr(data.post);
     const newdata = data.post.filter((post) => post.image !== '');
     setUserAlbumPostArr(newdata);
-    console.log(2);
   };
   useEffect(() => {
     getUserProfileInfo();

--- a/src/pages/Profile/UserProfile/UserProfile.jsx
+++ b/src/pages/Profile/UserProfile/UserProfile.jsx
@@ -31,15 +31,15 @@ const UserProfile = () => {
 
   const getUserProfileInfo = async () => {
     const data = await profileAPI.getUserInfo(pageAccount);
-    setUserProfile(data.profile);
     const ProfileData = { ...data.profile };
+    setUserProfile(data.profile);
     dispatch({ type: 'USERINFO_DATA', payload: ProfileData });
   };
 
   const getMyPost = async () => {
-    const data = await postAPI.getMyPost(user.token, pageAccount);
-    setUserPostArr(data.post);
+    const data = await postAPI.getMyPost(pageAccount);
     const newdata = data.post.filter((post) => post.image !== '');
+    setUserPostArr(data.post);
     setUserAlbumPostArr(newdata);
   };
   useEffect(() => {

--- a/src/pages/Profile/UserProfile/UserProfile.jsx
+++ b/src/pages/Profile/UserProfile/UserProfile.jsx
@@ -30,7 +30,6 @@ const UserProfile = () => {
   const pageAccount = location.pathname.split('/')[2];
 
   const getUserProfileInfo = async () => {
-    // const data = await profileAPI.getUserInfo(user.token, pageAccount);
     const data = await profileAPI.getUserInfo(pageAccount);
     setUserProfile(data.profile);
     const ProfileData = { ...data.profile };

--- a/src/pages/SearchUser/SearchUser.jsx
+++ b/src/pages/SearchUser/SearchUser.jsx
@@ -1,5 +1,4 @@
-import { useContext, useState, useEffect, useRef } from 'react';
-import { AuthContext } from '../../context/context';
+import { useState, useEffect, useRef } from 'react';
 import Nav from '../../components/Nav/Nav';
 import TabMenu from '../../components/common/TabMenu/TabMenu';
 import UserListItem from '../../components/UserListItem/UserListItem';
@@ -7,7 +6,6 @@ import searchAPI from '../../api/searchAPI';
 import * as S from './StyledSearchUser';
 
 const SearchUser = () => {
-  const { user } = useContext(AuthContext);
   const [keyword, setKeyword] = useState('');
   const [userData, setUserData] = useState([]);
   const [pieceUserData, setPieceUserData] = useState([]);
@@ -38,7 +36,7 @@ const SearchUser = () => {
   useEffect(() => {
     if (keyword) {
       const getUserData = async () => {
-        const data = await searchAPI.searchUser(keyword, user.token);
+        const data = await searchAPI.searchUser(keyword);
         setIndex(15);
         setPieceUserData([]);
         setUserData(data);


### PR DESCRIPTION
# <Refact> :  fetch 기반 코드를 axios 기반 코드로 통신 코드 전환

## [⚠️ 삭제된 파일 ]

- 없음.

## [✂️ 수정된 파일]

- src/api/profileAPI.js
- src/axios/axios.js
- package.json
- src/pages/Profile/UserProfile/UserProfile.jsx
...(생략)
FIles changed 참고

## [📝 생성된 파일]

- src/api/axios_profileAPI.js

## [📌 제안 사항]

- 없음.

## [📢 Notice]

- 별도의 api 파일에서 객체형태로 서버 통신 코드를 Fetch를 활용 하고 있었으며, 이를 axios 기반 코드로 전환하였음.
- Axios파일을 분리하여 instance를 생성하고 Request Interceptor 등록 후 Authorization 속성 token을 추가하였음.
- 서버에 데이터를 저장하거나 불러와야하는 page컴포넌트에서 Axios를 호출하여 데이터를 받아올 수 있도록 하였음.
- 전역에서 token 사용하기 위해 적용하였던 context API, useContext 를 제거하고, Axios 코드를 기반으로 하여 하나의 파일에서 작업을 수행할 수 있었음.
- Axios 통신 코드로 변경후 통신 코드량이 감소하여 가독성이 향상되었음.
